### PR TITLE
Fixes for ShellCheck errors

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master


### PR DESCRIPTION
Running the script through the [shellcheck](https://github.com/koalaman/shellcheck) static analysis tool returns the errors below:
```sh
$ shellcheck run.sh 

In run.sh line 1:
#!/usr/bin/with-contenv bashio
^-- SC1008 (error): This shebang was unrecognized. ShellCheck only supports sh/bash/dash/ksh. Add a 'shell' directive to specify.


In run.sh line 17:
export AWS_ACCESS_KEY_ID="$(bashio::config 'aws_access_key')"
       ^---------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In run.sh line 18:
export AWS_SECRET_ACCESS_KEY="$(bashio::config 'aws_secret_access_key')"
       ^-------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

For more information:
  https://www.shellcheck.net/wiki/SC1008 -- This shebang was unrecognized. Sh...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
```

SC2155 is detailed [here](https://www.shellcheck.net/wiki/SC2155), and SC1008 [here](https://www.shellcheck.net/wiki/SC1008).

ShellCheck can also run as a [GitHub action](https://github.com/marketplace/actions/shellcheck).

Also removed the executable bit from other non-executables that had it.