### PR TITLE
Upload from Supervisor's list of backups; use HA's name

### DIFF
--- a/amazon-s3-backup/config.json
+++ b/amazon-s3-backup/config.json
@@ -18,9 +18,9 @@
   "hassio_api": true,
   "hassio_role": "backup",
   "options": {
-    "aws_access_key": "",
-    "aws_secret_access_key": "",
-    "bucket_name": "",
+    "aws_access_key": null,
+    "aws_secret_access_key": null,
+    "bucket_name": null,
     "bucket_region": "eu-central-1",
     "storage_class": "STANDARD",
     "delete_local_backups": true,


### PR DESCRIPTION
Instead of using `aws s3 sync`, I loop through the backups from [supervisor's backup endpoint](https://developers.home-assistant.io/docs/api/supervisor/endpoints/#backup).

The backup API gives us the friendly name from the UI along with metadata we can send along to S3.

Example:
<img width="1609" alt="Screenshot 2023-03-08 at 15 07 38" src="https://user-images.githubusercontent.com/146013/223814123-15a3a566-a138-4091-b7d4-451fa0a04c4b.png">

I'm using this alongside https://github.com/jcwillox/hass-auto-backup to automate taking the actual backups.
