### PR TITLE
Add GLACIER_IR storage class option

### DIFF
--- a/amazon-s3-backup/config.json
+++ b/amazon-s3-backup/config.json
@@ -31,7 +31,7 @@
     "aws_secret_access_key": "password",
     "bucket_name": "str",
     "bucket_region": "list(us-east-1|us-east-2|us-west-1|us-west-2|af-south-1|ap-east-1|ap-south-2|ap-southeast-3|ap-southeast-4|ap-south-1|ap-northeast-3|ap-northeast-2|ap-southeast-1|ap-southeast-2|ap-northeast-1|ca-central-1|eu-central-1|eu-west-1|eu-west-2|eu-south-1|eu-west-3|eu-south-2|eu-north-1|eu-central-2|me-south-1|me-central-1|sa-east-1|us-gov-east-1|us-gov-west-1)",
-    "storage_class": "list(STANDARD|REDUCED_REDUNDANCY|STANDARD_IA|ONEZONE_IA|INTELLIGENT_TIERING|GLACIER|DEEP_ARCHIVE)",
+    "storage_class": "list(STANDARD|REDUCED_REDUNDANCY|STANDARD_IA|ONEZONE_IA|INTELLIGENT_TIERING|GLACIER|GLACIER_IR|DEEP_ARCHIVE)",
     "delete_local_backups": "bool",
     "local_backups_to_keep": "int"
   },


### PR DESCRIPTION
Adds Glacier Instant Retrieval (Glacier IR) as a storage class option.

Glacier IR is ~3x cheaper than Standard IA.

`GLACIER_IR` was obtained from https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html (see valid values for `x-amz-storage-class`).