### PR TITLE
Use hammer to squash "pipp3 install aws-cli" failure: "error: externally-managed-environment"

### DIFF
--- a/amazon-s3-backup/Dockerfile
+++ b/amazon-s3-backup/Dockerfile
@@ -14,6 +14,6 @@ RUN apk add -v --update --no-cache \
         less \
         jq \
         && \
-    pip3 install --upgrade awscli
+    pip3 install --break-system-packages --upgrade awscli
     
 CMD [ "/run.sh" ]  


### PR DESCRIPTION
Attempt to overcome install error:

Failed to to call /addons/1244bd6e_amazon-s3-backup/install - The command '/bin/ash -o pipefail -c apk add -v --update --no-cache python3 py3-pip groff less jq && pip3 install --upgrade awscli' returned a non-zero code: 1

> pip3 install --update aws-cli
error: externally-managed-environment