### PR TITLE
fix: broken install of aws-cli

### DIFF
--- a/amazon-s3-backup/Dockerfile
+++ b/amazon-s3-backup/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add -v --update --no-cache \
         groff \
         less \
         jq \
-        && \
-    pip3 install --upgrade awscli
+        aws-cli
     
 CMD [ "/run.sh" ]  


### PR DESCRIPTION
pip upgrade fails due to permission to modify the global python installation

fixes: #17 